### PR TITLE
Ensure no concurrency initialization in Nativity class moniker

### DIFF
--- a/windows/LiferayNativityShellExtensions/LiferayNativityOverlays/LiferayNativityOverlay.cpp
+++ b/windows/LiferayNativityShellExtensions/LiferayNativityOverlays/LiferayNativityOverlay.cpp
@@ -38,18 +38,18 @@ IFACEMETHODIMP LiferayNativityOverlay::IsMemberOf(PCWSTR pwszPath, DWORD dwAttri
 {
 	NativityUtil connection;
 	if (!NativityUtil::Find(pwszPath, connection)) {
-		return MAKE_HRESULT(S_FALSE, 0, 0);
+		return S_FALSE;
 	}
 
 	if (!connection->OverlaysEnabled()) {
-		return MAKE_HRESULT(S_FALSE, 0, 0);
+		return S_FALSE;
 	}
 
 	if (!IsMoniteredFileState(connection, pwszPath)) {
-		return MAKE_HRESULT(S_FALSE, 0, 0);
+		return S_FALSE;
 	}
 
-	return MAKE_HRESULT(S_OK, 0, 0);
+	return S_OK;
 }
 
 IFACEMETHODIMP LiferayNativityOverlay::GetOverlayInfo(PWSTR pwszIconFile, int cchMax, int* pIndex, DWORD* pdwFlags)

--- a/windows/LiferayNativityShellExtensions/LiferayNativityUtil/NativityUtil.h
+++ b/windows/LiferayNativityShellExtensions/LiferayNativityUtil/NativityUtil.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <memory>
-#include <string_view>
+#include <string>
 #include "API.h"
 
 namespace Nativity::Util


### PR DESCRIPTION
Effectively `static com_ptr` in `Find()` was concurrently initialized, which resulted in some copies being freed between threads.